### PR TITLE
Remove AltAccessions in favor of FileAccessionMappings (GSI-2293)

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -14,4 +14,4 @@ file_deletion_request_topic: file-deletion-requests
 file_deletion_request_type: file_deletion_requested
 file_internally_registered_topic: internal_file_registry
 file_internally_registered_type: file_registered
-accession_map_topic: accession-maps
+accession_map_topic: file-accession-mappings

--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -14,4 +14,4 @@ file_deletion_request_topic: file-deletion-requests
 file_deletion_request_type: file_deletion_requested
 file_internally_registered_topic: internal_file_registry
 file_internally_registered_type: file_registered
-alt_accession_topic: alt-accessions
+accession_map_topic: accession-maps

--- a/README.md
+++ b/README.md
@@ -233,11 +233,15 @@ The service requires the following configuration parameters:
   null
   ```
 
-- <a id="properties/alt_accession_topic"></a>**`alt_accession_topic`** *(string, required)*: The name of the topic used for AltAccession events.
+- <a id="properties/accession_map_topic"></a>**`accession_map_topic`** *(string, required)*: The name of the topic used for file accession map events.
 
   Examples:
   ```json
-  "alt-accessions"
+  "accession-maps"
+  ```
+
+  ```json
+  "file-accession-maps"
   ```
 
 - <a id="properties/file_deletion_request_topic"></a>**`file_deletion_request_topic`** *(string, required)*: The name of the topic to receive events informing about files to delete.

--- a/config_schema.json
+++ b/config_schema.json
@@ -246,12 +246,13 @@
       ],
       "title": "Mongo Timeout"
     },
-    "alt_accession_topic": {
-      "description": "The name of the topic used for AltAccession events",
+    "accession_map_topic": {
+      "description": "The name of the topic used for file accession map events",
       "examples": [
-        "alt-accessions"
+        "accession-maps",
+        "file-accession-maps"
       ],
-      "title": "Alt Accession Topic",
+      "title": "Accession Map Topic",
       "type": "string"
     },
     "file_deletion_request_topic": {
@@ -470,7 +471,7 @@
     "kafka_servers",
     "mongo_dsn",
     "db_name",
-    "alt_accession_topic",
+    "accession_map_topic",
     "file_deletion_request_topic",
     "file_deletion_request_type",
     "file_internally_registered_topic",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,4 +1,4 @@
-accession_map_topic: accession-maps
+accession_map_topic: file-accession-mappings
 api_root_path: ''
 auto_reload: false
 cors_allow_credentials: null

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,4 +1,4 @@
-alt_accession_topic: alt-accessions
+accession_map_topic: accession-maps
 api_root_path: ''
 auto_reload: false
 cors_allow_credentials: null

--- a/src/dins/adapters/inbound/event_sub.py
+++ b/src/dins/adapters/inbound/event_sub.py
@@ -13,16 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Inbound event subscriber translators for file registration, dataset, and AltAccession events."""
+"""Inbound event subscriber translators for file registration, dataset, and accession map events."""
 
 import logging
 
 from ghga_event_schemas.configs import (
     DatasetEventsConfig,
+    FileAccessionMappingEventsConfig,
     FileDeletionRequestEventsConfig,
     FileInternallyRegisteredEventsConfig,
 )
 from ghga_event_schemas.pydantic_ import (
+    FileAccessionMapping,
     FileDeletionRequested,
     FileInternallyRegistered,
     MetadataDatasetID,
@@ -32,11 +34,9 @@ from ghga_event_schemas.validation import get_validated_payload
 from hexkit.custom_types import Ascii, JsonObject
 from hexkit.protocols.daosub import DaoSubscriberProtocol
 from hexkit.protocols.eventsub import EventSubscriberProtocol
-from pydantic import UUID4, Field
-from pydantic_settings import BaseSettings
+from pydantic import UUID4
 
 from dins.constants import TRACER
-from dins.core.models import AltAccession, AltAccessionType
 from dins.ports.inbound.information_service import InformationServicePort
 
 log = logging.getLogger(__name__)
@@ -159,52 +159,32 @@ class EventSubTranslator(EventSubscriberProtocol):
         )
 
 
-class OutboxSubConfig(BaseSettings):
-    """Config for listening to events carrying state updates for AltAccessions.
-
-    The event types are hardcoded by `hexkit`.
-    """
-
-    alt_accession_topic: str = Field(
-        default=...,
-        description="The name of the topic used for AltAccession events",
-        examples=["alt-accessions"],
-    )
-
-
-class AltAccessionOutboxTranslator(DaoSubscriberProtocol[AltAccession]):
-    """An outbox subscriber event translator for AltAccession outbox events."""
+class AccessionMapOutboxTranslator(DaoSubscriberProtocol[FileAccessionMapping]):
+    """An outbox subscriber event translator for AccessionMap outbox events."""
 
     event_topic: str
-    dto_model = AltAccession
+    dto_model = FileAccessionMapping
 
     def __init__(
         self,
         *,
-        config: OutboxSubConfig,
+        config: FileAccessionMappingEventsConfig,
         information_service: InformationServicePort,
     ):
         """Initialize the outbox subscriber"""
-        self.event_topic = config.alt_accession_topic
+        self.event_topic = config.accession_map_topic
         self._information_service = information_service
 
-    @TRACER.start_as_current_span("AltAccessionOutboxTranslator.changed")
-    async def changed(self, resource_id: str, update: AltAccession) -> None:
-        """Process an AltAccession event."""
-        if update.type == AltAccessionType.FILE_ID:
-            log.info(
-                "Received upsertion outbox event for AltAccession for accession %s.",
-                resource_id,
-            )
-            await self._information_service.store_accession_map(accession_map=update)
-        else:
-            log.info(
-                "Ignoring upsertion event for %s-type AltAccession for %s.",
-                update.type,
-                resource_id,
-            )
+    @TRACER.start_as_current_span("AccessionMapOutboxTranslator.changed")
+    async def changed(self, resource_id: str, update: FileAccessionMapping) -> None:
+        """Process an AccessionMap event."""
+        log.info(
+            "Received upsertion outbox event for AccessionMap for accession %s.",
+            resource_id,
+        )
+        await self._information_service.store_accession_map(accession_map=update)
 
-    @TRACER.start_as_current_span("AltAccessionOutboxTranslator.deleted")
+    @TRACER.start_as_current_span("AccessionMapOutboxTranslator.deleted")
     async def deleted(self, resource_id: str) -> None:
         """Delete the mapping for a given accession"""
         log.info(

--- a/src/dins/adapters/outbound/dao.py
+++ b/src/dins/adapters/outbound/dao.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """DAO translators for database access."""
 
+from ghga_event_schemas.pydantic_ import FileAccessionMapping
 from hexkit.protocols.dao import DaoFactoryProtocol
 from hexkit.providers.mongodb import MongoDbIndex
 
@@ -40,12 +41,12 @@ async def get_file_information_dao(
 async def get_file_accession_map_dao(
     *, dao_factory: DaoFactoryProtocol
 ) -> FileAccessionMapDaoPort:
-    """Set up the AltAccession DAO using the specified provider of the DaoFactoryProtocol."""
+    """Set up the FileAccessionMap DAO using the specified provider of the DaoFactoryProtocol."""
     return await dao_factory.get_dao(
         name="fileAccessionMaps",
-        dto_model=models.AltAccession,
-        id_field="pid",
-        indexes=[MongoDbIndex(fields="id", properties={"unique": True})],
+        dto_model=FileAccessionMapping,
+        id_field="accession",
+        indexes=[MongoDbIndex(fields="file_id", properties={"unique": True})],
     )
 
 

--- a/src/dins/config.py
+++ b/src/dins/config.py
@@ -14,13 +14,14 @@
 # limitations under the License.
 """Config Parameter Modeling and Parsing"""
 
+from ghga_event_schemas.configs import FileAccessionMappingEventsConfig
 from ghga_service_commons.api import ApiConfigBase
 from hexkit.config import config_from_yaml
 from hexkit.log import LoggingConfig
 from hexkit.opentelemetry import OpenTelemetryConfig
 from hexkit.providers.mongokafka import MongoKafkaConfig
 
-from dins.adapters.inbound.event_sub import EventSubTranslatorConfig, OutboxSubConfig
+from dins.adapters.inbound.event_sub import EventSubTranslatorConfig
 from dins.constants import SERVICE_NAME
 
 
@@ -28,7 +29,7 @@ from dins.constants import SERVICE_NAME
 class Config(
     ApiConfigBase,
     EventSubTranslatorConfig,
-    OutboxSubConfig,
+    FileAccessionMappingEventsConfig,
     MongoKafkaConfig,
     LoggingConfig,
     OpenTelemetryConfig,

--- a/src/dins/core/information_service.py
+++ b/src/dins/core/information_service.py
@@ -16,9 +16,9 @@
 
 import logging
 from contextlib import suppress
-from uuid import UUID
 
 from ghga_event_schemas.pydantic_ import (
+    FileAccessionMapping,
     FileInternallyRegistered,
     MetadataDatasetOverview,
 )
@@ -26,7 +26,6 @@ from hexkit.protocols.dao import NoHitsFoundError, ResourceNotFoundError
 from pydantic import UUID4
 
 from dins.core.models import (
-    AltAccession,
     DatasetFileAccessions,
     DatasetFileInformation,
     FileAccession,
@@ -107,12 +106,12 @@ class InformationService(InformationServicePort):
     async def delete_file_information(self, file_id: UUID4):
         """Delete FileInformation for the given file ID.
 
-        If no AltAccession record is found for the file ID, logs and returns early.
-        If the AltAccession record exists but no FileInformation is stored, logs and returns.
+        If no accession map is found for the file ID, logs and returns early.
+        If the accession map exists but no FileInformation is stored, logs and returns.
         """
         try:
             accession_map = await self._accession_map_dao.find_one(
-                mapping={"id": str(file_id)}
+                mapping={"file_id": file_id}
             )
         except NoHitsFoundError:
             log.info(
@@ -121,7 +120,7 @@ class InformationService(InformationServicePort):
             return
 
         try:
-            accession = accession_map.pid
+            accession = accession_map.accession
             await self._file_information_dao.delete(accession)
         except ResourceNotFoundError:
             log.info(
@@ -137,12 +136,12 @@ class InformationService(InformationServicePort):
     ) -> None:
         """Decide how to handle a new file registration.
 
-        If a corresponding AltAccession record already exists, merge and store FileInformation.
+        If a corresponding FileAccessionMap already exists, merge and store FileInformation.
         If not, temporarily store the essential fields as a PendingFileInfo instance.
         """
         try:
             accession_map = await self._accession_map_dao.find_one(
-                mapping={"id": str(file.file_id)}
+                mapping={"file_id": file.file_id}
             )
         except NoHitsFoundError:
             pending = PendingFileInfo(
@@ -154,7 +153,7 @@ class InformationService(InformationServicePort):
             await self.store_pending_file_info(pending=pending)
         else:
             file_information = FileInformation(
-                accession=accession_map.pid,
+                accession=accession_map.accession,
                 size=file.decrypted_size,
                 sha256_hash=file.decrypted_sha256,
                 storage_alias=file.storage_alias,
@@ -186,16 +185,15 @@ class InformationService(InformationServicePort):
                 log.error(mismatch)
                 raise mismatch
 
-    async def store_accession_map(self, *, accession_map: AltAccession) -> None:
-        """Upsert an accession map using a FILE_ID-type AltAccession, then
-        merge any waiting PendingFileInfo into FileInformation.
+    async def store_accession_map(self, *, accession_map: FileAccessionMapping) -> None:
+        """Upsert an accession map, then merge any waiting PendingFileInfo into FileInformation.
 
         Raises MismatchingFileInformationAlreadyRegistered if the accession is already mapped
         to a different file_id and a FileInformation record already exists for this accession.
         Ignores duplicates. After upserting, triggers a merge if a PendingFileInfo
         record exists for the associated file_id.
         """
-        accession = accession_map.pid
+        accession = accession_map.accession
         try:
             existing_map = await self._accession_map_dao.get_by_id(accession)
         except ResourceNotFoundError:
@@ -204,15 +202,15 @@ class InformationService(InformationServicePort):
         # Handle potential inconsistencies
         if existing_map is not None and accession_map != existing_map:
             with suppress(ResourceNotFoundError):
-                await self._file_information_dao.get_by_id(accession_map.pid)
+                await self._file_information_dao.get_by_id(accession_map.accession)
                 log.error(
                     "FileInformation is already registered for accession %s, but this"
                     + " accession map is different from what is stored already.",
                     accession,
                     extra={
                         "accession": accession,
-                        "currently_mapped_file_id": existing_map.id,
-                        "new_file_id": accession_map.id,
+                        "currently_mapped_file_id": existing_map.file_id,
+                        "new_file_id": accession_map.file_id,
                     },
                 )
                 raise self.MismatchingFileInformationAlreadyRegistered(
@@ -223,17 +221,15 @@ class InformationService(InformationServicePort):
         await self._accession_map_dao.upsert(accession_map)
         log.info(
             "Upserted accession map for accession %s, file ID %s.",
-            accession_map.pid,
-            accession_map.id,
+            accession_map.accession,
+            accession_map.file_id,
         )
 
         # Now check to see if the corresponding PendingFileInfo is already in the DB.
         #  We do this even if the mapping is a duplicate, as it provides a path for
         #  error recovery if the two components make it to the DB without being merged.
         try:
-            pending = await self._pending_file_info_dao.get_by_id(
-                UUID(accession_map.id)
-            )
+            pending = await self._pending_file_info_dao.get_by_id(accession_map.file_id)
         except ResourceNotFoundError:
             log.info(
                 "Accession map received for %s but still waiting for FileInternallyRegistered event.",
@@ -243,7 +239,7 @@ class InformationService(InformationServicePort):
 
         # PendingFileInfo exists, register the FileInformation
         file_information = FileInformation(
-            accession=accession_map.pid,
+            accession=accession_map.accession,
             size=pending.decrypted_size,
             sha256_hash=pending.decrypted_sha256,
             storage_alias=pending.storage_alias,
@@ -251,21 +247,21 @@ class InformationService(InformationServicePort):
         log.info(
             "Merged accession map for %s with file info for %s, registering FileInformation.",
             accession,
-            accession_map.id,
+            accession_map.file_id,
         )
         await self.register_file_information(file_information=file_information)
 
         # Delete the pending file info. If this doesn't get done, the data will linger
         #  but otherwise should not cause problems.
-        await self._pending_file_info_dao.delete(UUID(accession_map.id))
+        await self._pending_file_info_dao.delete(accession_map.file_id)
         log.info(
             "Merged pending file info for file_id %s with accession %s.",
-            accession_map.id,
-            accession_map.pid,
+            accession_map.file_id,
+            accession_map.accession,
         )
 
     async def delete_accession_map(self, *, accession: str) -> None:
-        """Delete the accession map (AltAccession) entry identified by the given GHGA accession (AltAccession.pid).
+        """Delete the accession map entry identified by the given accession.
 
         No error is raised if no entry exists for the accession.
         """

--- a/src/dins/core/models.py
+++ b/src/dins/core/models.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 """Models for internal representation"""
 
-from enum import StrEnum
-
-from ghga_service_commons.utils.utc_dates import UTCDatetime
 from pydantic import (
     UUID4,
     BaseModel,
@@ -25,31 +22,12 @@ from pydantic import (
 )
 
 __all__ = [
-    "AltAccession",
-    "AltAccessionType",
     "DatasetFileAccessions",
     "DatasetFileInformation",
     "FileAccession",
     "FileInformation",
     "PendingFileInfo",
 ]
-
-
-class AltAccessionType(StrEnum):
-    """Kinds of alternative accessions."""
-
-    EGA = "EGA"
-    FILE_ID = "FILE_ID"
-    GHGA_LEGACY = "GHGA_LEGACY"
-
-
-class AltAccession(BaseModel):
-    """Stores alternative accessions referencing a primary accession."""
-
-    id: str
-    pid: str
-    type: AltAccessionType
-    created: UTCDatetime
 
 
 class FileAccession(BaseModel):
@@ -104,7 +82,7 @@ class DatasetFileInformation(BaseModel):
 
 
 class PendingFileInfo(BaseModel):
-    """Temporarily stored file registration data awaiting the corresponding AltAccession record."""
+    """Temporarily stored file registration data awaiting the corresponding accession map."""
 
     file_id: UUID4 = Field(
         default=..., description="Unique identifier for the file upload"

--- a/src/dins/inject.py
+++ b/src/dins/inject.py
@@ -28,7 +28,7 @@ from hexkit.providers.akafka import (
 from hexkit.providers.mongodb import MongoDbDaoFactory
 
 from dins.adapters.inbound.event_sub import (
-    AltAccessionOutboxTranslator,
+    AccessionMapOutboxTranslator,
     EventSubTranslator,
 )
 from dins.adapters.inbound.fastapi_ import dummies
@@ -91,7 +91,7 @@ async def prepare_event_subscriber(
         event_sub_translator = EventSubTranslator(
             config=config, information_service=information_service
         )
-        accession_map_subscriber = AltAccessionOutboxTranslator(
+        accession_map_subscriber = AccessionMapOutboxTranslator(
             config=config,
             information_service=information_service,
         )

--- a/src/dins/ports/inbound/dao.py
+++ b/src/dins/ports/inbound/dao.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 """DAO interfaces for database access."""
 
+from ghga_event_schemas import pydantic_ as event_schemas
 from hexkit.protocols.dao import Dao
 
 from dins.core import models
 
 DatasetDaoPort = Dao[models.DatasetFileAccessions]
-FileAccessionMapDaoPort = Dao[models.AltAccession]
+FileAccessionMapDaoPort = Dao[event_schemas.FileAccessionMapping]
 FileInformationDaoPort = Dao[models.FileInformation]
 PendingFileInfoDaoPort = Dao[models.PendingFileInfo]

--- a/src/dins/ports/inbound/information_service.py
+++ b/src/dins/ports/inbound/information_service.py
@@ -19,12 +19,7 @@ from abc import ABC, abstractmethod
 import ghga_event_schemas.pydantic_ as event_schemas
 from pydantic import UUID4
 
-from dins.core.models import (
-    AltAccession,
-    DatasetFileInformation,
-    FileInformation,
-    PendingFileInfo,
-)
+from dins.core.models import DatasetFileInformation, FileInformation, PendingFileInfo
 
 
 class InformationServicePort(ABC):
@@ -80,8 +75,8 @@ class InformationServicePort(ABC):
     async def delete_file_information(self, file_id: UUID4) -> None:
         """Delete FileInformation for the given file ID.
 
-        If no AltAccession record is found for the file ID, logs and returns early.
-        If the AltAccession record exists but no FileInformation is stored, logs and returns.
+        If no accession map is found for the file ID, logs and returns early.
+        If the accession map exists but no FileInformation is stored, logs and returns.
         """
 
     @abstractmethod
@@ -90,7 +85,7 @@ class InformationServicePort(ABC):
     ) -> None:
         """Decide how to handle a new file registration.
 
-        If a corresponding AltAccession record already exists, merge and store FileInformation.
+        If a corresponding FileAccessionMap already exists, merge and store FileInformation.
         If not, temporarily store the essential fields as a PendingFileInfo instance.
         """
 
@@ -102,9 +97,10 @@ class InformationServicePort(ABC):
         """
 
     @abstractmethod
-    async def store_accession_map(self, *, accession_map: AltAccession) -> None:
-        """Upsert an accession map using a FILE_ID-type AltAccession, then
-        merge any waiting PendingFileInfo into FileInformation.
+    async def store_accession_map(
+        self, *, accession_map: event_schemas.FileAccessionMapping
+    ) -> None:
+        """Upsert an accession map, then merge any waiting PendingFileInfo into FileInformation.
 
         Raises MismatchingFileInformationAlreadyRegistered if the accession is already mapped
         to a different file_id and a FileInformation record already exists for this accession.

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 import httpx
 import pytest
 import pytest_asyncio
+from ghga_event_schemas.pydantic_ import FileAccessionMapping
 from ghga_service_commons.api.testing import AsyncTestClient
 from hexkit.providers.akafka import KafkaEventSubscriber
 from hexkit.providers.akafka.testutils import KafkaFixture
@@ -32,7 +33,6 @@ from dins.adapters.outbound.dao import get_dataset_dao, get_file_information_dao
 from dins.config import Config
 from dins.core.information_service import InformationService
 from dins.core.models import (
-    AltAccession,
     DatasetFileAccessions,
     FileInformation,
     PendingFileInfo,
@@ -55,7 +55,7 @@ InMemFileInformationDao: type[FileInformationDaoPort] = new_mock_dao_class(  # t
     dto_model=FileInformation, id_field="accession"
 )
 InMemAccessionMapDao: type[FileAccessionMapDaoPort] = new_mock_dao_class(  # type: ignore
-    dto_model=AltAccession, id_field="pid"
+    dto_model=FileAccessionMapping, id_field="accession"
 )
 InMemPendingFileInfoDao: type[PendingFileInfoDaoPort] = new_mock_dao_class(  # type: ignore
     dto_model=PendingFileInfo, id_field="file_id"

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -14,4 +14,4 @@ file_deletion_request_topic: file-deletion-requests
 file_deletion_request_type: file_deletion_requested
 file_internally_registered_topic: internal_file_registry
 file_internally_registered_type: file_registered
-accession_map_topic: accession-maps
+accession_map_topic: file-accession-mappings

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -14,4 +14,4 @@ file_deletion_request_topic: file-deletion-requests
 file_deletion_request_type: file_deletion_requested
 file_internally_registered_topic: internal_file_registry
 file_internally_registered_type: file_registered
-alt_accession_topic: alt-accessions
+accession_map_topic: accession-maps

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -23,7 +23,6 @@ from hexkit.utils import now_utc_ms_prec
 from pydantic import UUID4
 
 from dins.core import models
-from dins.core.models import AltAccession, AltAccessionType
 
 BASE_DIR = Path(__file__).parent.resolve()
 
@@ -87,13 +86,10 @@ def make_metadata_dataset_overview(
 def make_accession_map(
     accession: str = "GHGA001",
     file_id: UUID4 | None = None,
-) -> AltAccession:
-    """Generate an AltAccession object for testing"""
-    return AltAccession(
-        pid=accession,
-        id=str(file_id or uuid4()),
-        type=AltAccessionType.FILE_ID,
-        created=now_utc_ms_prec(),
+) -> event_schemas.FileAccessionMapping:
+    """Generate a FileAccessionMapping object for testing"""
+    return event_schemas.FileAccessionMapping(
+        accession=accession, file_id=file_id or uuid4()
     )
 
 

--- a/tests/integration/test_typical_journey.py
+++ b/tests/integration/test_typical_journey.py
@@ -23,7 +23,6 @@ from hexkit.protocols.dao import ResourceNotFoundError
 
 from dins.adapters.outbound.dao import get_file_accession_map_dao
 from dins.core import models
-from dins.core.models import AltAccessionType
 from tests.fixtures.joint import JointFixture
 from tests.fixtures.utils import (
     ACCESSION1,
@@ -324,22 +323,22 @@ async def test_dataset_information_journey(
 
 
 async def test_accession_map_unique_file_id_index(joint_fixture: JointFixture):
-    """Verifies that the unique index on 'id' (file UUID) in the accession map collection works.
+    """Verifies that the unique index on 'file_id' in the accession map collection works.
 
-    Two different accessions must not be mapped to the same file UUID. The second
+    Two different accessions must not be mapped to the same file_id. The second
     event should fail due to the unique index and be sent to the DLQ.
     """
     # Publish and consume the first accession map event - should succeed
     await joint_fixture.kafka.publish_event(
         payload=ACCESSION_MAP_1.model_dump(),
         type_="upserted",
-        topic=joint_fixture.config.alt_accession_topic,
+        topic=joint_fixture.config.accession_map_topic,
         key=ACCESSION1,
     )
     await joint_fixture.event_subscriber.run(forever=False)
 
-    # Publish a second accession map with the same file UUID but a different accession.
-    # The unique index on 'id' should reject the insert and route the event to the DLQ.
+    # Publish a second accession map with the same file_id but a different accession.
+    # The unique index on file_id should reject the insert and route the event to the DLQ.
     duplicate_file_id_map = make_accession_map(accession=ACCESSION2, file_id=FILE_ID_1)
     async with joint_fixture.kafka.record_events(
         in_topic=joint_fixture.config.kafka_dlq_topic
@@ -347,38 +346,12 @@ async def test_accession_map_unique_file_id_index(joint_fixture: JointFixture):
         await joint_fixture.kafka.publish_event(
             payload=duplicate_file_id_map.model_dump(),
             type_="upserted",
-            topic=joint_fixture.config.alt_accession_topic,
+            topic=joint_fixture.config.accession_map_topic,
             key=ACCESSION2,
         )
         await joint_fixture.event_subscriber.run(forever=False)
 
     assert len(recorder.recorded_events) == 1
-
-
-async def test_non_file_id_alt_accession_is_ignored(joint_fixture: JointFixture):
-    """Verify that upserted AltAccession events with a type other than FILE_ID are ignored.
-
-    EGA and GHGA_LEGACY accession types carry no file-to-accession mapping relevant
-    to this service and must not be stored.
-    """
-    accession_map_dao = await get_file_accession_map_dao(
-        dao_factory=joint_fixture.mongodb.dao_factory
-    )
-
-    for non_file_id_type in (AltAccessionType.EGA, AltAccessionType.GHGA_LEGACY):
-        ignored_map = make_accession_map(accession=ACCESSION1, file_id=FILE_ID_1)
-        ignored_map = ignored_map.model_copy(update={"type": non_file_id_type})
-
-        await joint_fixture.kafka.publish_event(
-            payload=ignored_map.model_dump(),
-            type_="upserted",
-            topic=joint_fixture.config.alt_accession_topic,
-            key=ACCESSION1,
-        )
-        await joint_fixture.event_subscriber.run(forever=False)
-
-        with pytest.raises(ResourceNotFoundError):
-            await accession_map_dao.get_by_id(ACCESSION1)
 
 
 async def test_accession_map_deletion_event(joint_fixture: JointFixture):
@@ -391,7 +364,7 @@ async def test_accession_map_deletion_event(joint_fixture: JointFixture):
     await joint_fixture.kafka.publish_event(
         payload=ACCESSION_MAP_1.model_dump(),
         type_="upserted",
-        topic=joint_fixture.config.alt_accession_topic,
+        topic=joint_fixture.config.accession_map_topic,
         key=ACCESSION1,
     )
     await joint_fixture.event_subscriber.run(forever=False)
@@ -403,7 +376,7 @@ async def test_accession_map_deletion_event(joint_fixture: JointFixture):
     await joint_fixture.kafka.publish_event(
         payload={},
         type_="deleted",
-        topic=joint_fixture.config.alt_accession_topic,
+        topic=joint_fixture.config.accession_map_topic,
         key=ACCESSION1,
     )
     await joint_fixture.event_subscriber.run(forever=False)

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -250,7 +250,7 @@ async def test_store_accession_map_happy(rig: JointRig):
     accession_map = make_accession_map()
     await rig.information_service.store_accession_map(accession_map=accession_map)
 
-    stored_map = await rig.accession_map_dao.get_by_id(accession_map.pid)
+    stored_map = await rig.accession_map_dao.get_by_id(accession_map.accession)
     assert stored_map == accession_map
 
 
@@ -289,11 +289,11 @@ async def test_delete_accession_map(rig: JointRig):
     exists as well as when it doesn't exist.
     """
     accession_map = make_accession_map()
-    accession = accession_map.pid
+    accession = accession_map.accession
     await rig.accession_map_dao.insert(accession_map)
 
     await rig.information_service.delete_accession_map(accession=accession)
-    remaining = rig.accession_map_dao.find_all(mapping={"pid": accession})
+    remaining = rig.accession_map_dao.find_all(mapping={"accession": accession})
     assert len([x async for x in remaining]) == 0
 
     # Deleting a non-existent accession map should not raise an error


### PR DESCRIPTION
We decided not to use AltAccessions to communicate file-accession mappings, so this PR reverts DINS to FileAccessionMappings once more.